### PR TITLE
Change apiHost to baseApiUri

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -8,7 +8,7 @@
       bmc.configure({
         graphqlUri: 'http://0.0.0.0:11001',
         tenantKey: 'acbm_fcp',
-        apiHost: 'manage.forconstructionpros.com'
+        baseApiUri: 'https://manage.forconstructionpros.com'
       });
     </script>
     <link rel="stylesheet" href="./dist/latest/bmc.css">

--- a/src/apollo/create-provider.js
+++ b/src/apollo/create-provider.js
@@ -1,14 +1,14 @@
 import VueApollo from 'vue-apollo';
 import createApolloClient from './create-client';
 
-export default ({ graphqlUri, tenantKey, apiHost } = {}) => {
-  const host = apiHost || window.location.hostname;
-  if (!graphqlUri || !tenantKey || !host) {
-    throw new Error('The graphqlUri, tenantKey, and apiHost options are required to create the BaseCMS Apollo Provider.');
+export default ({ graphqlUri, tenantKey, baseApiUri } = {}) => {
+  const apiUri = baseApiUri || window.location.origin;
+  if (!graphqlUri || !tenantKey || !apiUri) {
+    throw new Error('The graphqlUri, tenantKey, and baseApiUri options are required to create the BaseCMS Apollo Provider.');
   }
   const headers = {
     'x-tenant-key': tenantKey,
-    'x-base4-api-hostname': apiHost || window.location.hostname,
+    'x-base4-api-uri': apiUri,
   };
   return new VueApollo({
     defaultClient: createApolloClient({ uri: graphqlUri, headers }),

--- a/src/config.js
+++ b/src/config.js
@@ -15,11 +15,11 @@ const getApolloProvider = () => {
 };
 
 const configure = (options = {}) => {
-  const { graphqlUri, tenantKey, apiHost } = options;
+  const { graphqlUri, tenantKey, baseApiUri } = options;
   if (hasConfigured()) {
     warn('BaseCMS components have already been configured. The following config changes will NOT be applied.', options);
   } else {
-    apolloProvider = createProvider({ graphqlUri, tenantKey, apiHost });
+    apolloProvider = createProvider({ graphqlUri, tenantKey, baseApiUri });
     config = options;
   }
 };

--- a/src/main.js
+++ b/src/main.js
@@ -9,7 +9,7 @@ Vue.config.productionTip = false;
 configure({
   graphqlUri: 'http://0.0.0.0:11001',
   tenantKey: 'acbm_fcp',
-  apiHost: 'manage.forconstructionpros.com',
+  baseApiUri: 'https://manage.forconstructionpros.com',
 });
 
 new Vue({


### PR DESCRIPTION
The `baseApiUri` parameter, if not provided, will now use `window.location.origin` as the default value (instead of `hostname`).

**Requires base-cms/base-cms#193 to be merged and deployed**