### PR TITLE
Fire add and remove events from Related Taxonomies component

### DIFF
--- a/src/components/common/fields/taxonomies.vue
+++ b/src/components/common/fields/taxonomies.vue
@@ -1,8 +1,13 @@
 <template>
+  <!--
+    Note: `auto-load-root-options` should be false. Due to a bug in treeselect,
+    removing an item before the options are loaded actually fires the _select_ event,
+    not the _deselect_ event. This, then, causes a duplicate ID error.
+  -->
   <tree-select
     v-model="currentTaxonomies"
     value-format="object"
-    :auto-load-root-options="false"
+    :auto-load-root-options="true"
     :backspace-removes="false"
     :clearable="clearable"
     :disabled="disabled"
@@ -16,6 +21,8 @@
     @open="$emit('open')"
     @close="$emit('close')"
     @input="emitChange"
+    @select="emitSelect"
+    @deselect="emitDeselect"
     search-nested
   >
     <div slot="value-label" slot-scope="{ node }">{{ node.raw.title }} [{{ node.id }}]</div>

--- a/src/components/common/fields/taxonomies.vue
+++ b/src/components/common/fields/taxonomies.vue
@@ -21,8 +21,6 @@
     @open="$emit('open')"
     @close="$emit('close')"
     @input="emitChange"
-    @select="emitSelect"
-    @deselect="emitDeselect"
     search-nested
   >
     <div slot="value-label" slot-scope="{ node }">{{ node.raw.title }} [{{ node.id }}]</div>


### PR DESCRIPTION
The `add` and `remove` events will fire when taxonomy items are added or removed. These events will also provide the current and previous taxonomies array, along with the taxonomy object that was added or removed. Finally, all events will include the originally selected array of taxonomies.

The common `taxonomies` field component will now auto-load the available taxonomy options. This was done to avoid a bug in tree-select. See the comment in the diff for more details.